### PR TITLE
Fixed handling of uppercase http/https urls

### DIFF
--- a/src/main/java/trikita/obsqr/QrContent.java
+++ b/src/main/java/trikita/obsqr/QrContent.java
@@ -133,7 +133,8 @@ public abstract class QrContent {
 			super(c, s, c.getString(R.string.title_url), c.getString(R.string.action_url), url(s));
 		}
 		private static Spannable url(String s) {
-			if (!s.startsWith("http:") && !s.startsWith("https:") && !s.startsWith("ftp:")) {
+			String lowerUrl = s.toLowerCase();
+			if (!lowerUrl.startsWith("http:") && !lowerUrl.startsWith("https:") && !lowerUrl.startsWith("ftp:")) {
 				s = "http://" + s;
 			}
 			return spannable(s);
@@ -353,4 +354,3 @@ public abstract class QrContent {
 		}
 	}
 }
-


### PR DESCRIPTION
Previously HTTP: and HTTPS: caused the parser to be mistaken with the url to not have a scheme and adds an extra scheme, making it HTTP://HTTP://WWW... thus making it fail parsing the url properly.

This PR fixes it, as the string is handled in lowercase when checking for a scheme.